### PR TITLE
Drop `php-cs-fixer/php-cs-fixer` in favor of `nikic/php-parser`

### DIFF
--- a/app/NodeVisitor/RemoveFinalKeywordVisitor.php
+++ b/app/NodeVisitor/RemoveFinalKeywordVisitor.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\NodeVisitor;
+
+use PhpParser\Node;
+use PhpParser\NodeVisitorAbstract;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Comment\Doc;
+
+final class RemoveFinalKeywordVisitor extends NodeVisitorAbstract
+{
+    public function __construct(
+       private bool $markFinal = false,
+       private bool $markReadOnly = false
+    ) {
+    }
+    public function beforeTraverse(array $nodes): mixed
+    {
+        return null;
+    }
+
+    public function enterNode(Node $node): mixed
+    {
+        return null;
+    }
+
+    public function leaveNode(Node $node): mixed
+    {
+        if (! $node instanceof ClassMethod && ! $node instanceof Class_) {
+            return null;
+        }
+
+        $docComment = $node->getDocComment()?->getText();
+
+        if ($node->flags & Class_::MODIFIER_FINAL) {
+            // remove final keyword
+            $node->flags = $node->flags & ~ Class_::MODIFIER_FINAL;
+
+            // Add @final to docblock
+            if ($this->markFinal) {
+                if (! $docComment) {
+                    $docComment = "/**\n * @final\n */";
+                } else {
+                    $docComment = str_replace('*/', '*'.PHP_EOL.' * @final'.PHP_EOL.' */', $docComment);
+                }
+
+                $node->setDocComment(new Doc($docComment));
+            }
+
+        }
+
+        if ($node->flags & Class_::MODIFIER_READONLY) {
+            // remove readonly keyword
+            $node->flags = $node->flags & ~ Class_::MODIFIER_READONLY;
+
+            // Add @readonly to docblock
+            if ($this->markReadOnly)
+            {
+                if (! $docComment) {
+                    $docComment = "/**\n * @readonly\n */";
+                } else {
+                    $docComment = str_replace('*/', '*'.PHP_EOL.' * @readonly'.PHP_EOL.' */', $docComment);
+                }
+
+                $node->setDocComment(new Doc($docComment));
+            }
+        }
+
+        return $node;
+    }
+
+    public function afterTraverse(array $nodes): mixed
+    {
+        return null;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         }
     ],
     "require": {
-        "php": "^8.1"
+        "php": "^8.1",
+        "nikic/php-parser": "^4.17"
     },
     "require-dev": {
         "laravel-zero/framework": "^10.0.2",


### PR DESCRIPTION
Hi,

I would like to apologize for the recent experience you had to go through due to the act of sabotage and manipulation towards this project, caused by such unethical actions.

This patch combats https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7343, via the following changes:

- Replace PHP CS Fixer with PHP-Parser
- RemoveFinalKeyword Implementation
- RemoveReadOnlyKeyword Implementation
- Add `@final` DocBlock via `--mark-final` 
- Add `@readonly` DocBlock via `--mark-readonly`

It's important to note that these actions were deemed necessary due to the unethical nature and (in my opinion oppressive behavior) their violation of the spirit of open-source.

I've enabled `Allow edits by maintainers`; feel free to review the changes, provide any feedback, or make changes directly.

Thank you for your attention.