### PR TITLE
Remove the interface use which is restricting the design, down with the bourgeoisie!

### DIFF
--- a/app/RemoveFinalKeywordFixer.php
+++ b/app/RemoveFinalKeywordFixer.php
@@ -13,7 +13,7 @@ use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use SplFileInfo;
 
-class RemoveFinalKeywordFixer extends AbstractFixer implements ConfigurableFixerInterface
+class RemoveFinalKeywordFixer extends AbstractFixer
 {
     /**
      * Get the name of the fixer.


### PR DESCRIPTION
Interfaces are a design restriction by the target author, they IMPOSE THEIR WILL across the ether onto us.

Well I say **enough**, down with the bourgeoisie, down with the oppression and design goals of others! Forwards comrades, seize the means of production (and, given time, perhaps also testing and staging)!